### PR TITLE
Add issue page tour (WIP)

### DIFF
--- a/src/components/issue-page/index.tsx
+++ b/src/components/issue-page/index.tsx
@@ -1,7 +1,8 @@
 // tslint:disable:no-expression-statement
-import React from 'react'
+import React, {useEffect} from 'react'
 import IssueMetadata from './overview'
 import IssueTimelineView, { IssueTimelineViewProps } from './timeline'
+import { startTour } from './tour'
 
 export type LoadedIssueContentProps = {
   avatarUrl?: string
@@ -14,7 +15,7 @@ function useDemo(issue: Issue, postComment: LoadedIssueContentProps['postComment
   if (issue.status === 'opened') {
     setTimeout(() => {
       changeStatus({ username: 'devdiva', avatarUrl: '/devdiva.png' }, 'acknowledged', {
-        html: `<div>I am able to reproduce this on our end, sorry about that! We'll get working on a fix right away</div>`,
+        html: `<div id="diva-acknowledged">I am able to reproduce this on our end, sorry about that! We'll get working on a fix right away</div>`,
       })
     }, 3000)
   }
@@ -30,6 +31,12 @@ function useDemo(issue: Issue, postComment: LoadedIssueContentProps['postComment
 
 export default function LoadedIssueContent({ avatarUrl, issue, postComment, changeStatus }: LoadedIssueContentProps): JSX.Element {
   useDemo(issue, postComment, changeStatus)
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      startTour() // tslint:disable-line:no-expression-statement
+    }
+  }, [])
 
   return (
     <div className="issue-body">

--- a/src/components/issue-page/tour.tsx
+++ b/src/components/issue-page/tour.tsx
@@ -34,7 +34,7 @@ const steps = Object.freeze([
         action(): void {
           this.next()
         },
-        disabled: true
+        disabled: true,
       },
     ],
   },
@@ -76,7 +76,7 @@ export function startTour(): any {
     postButton.click() // tslint:disable-line:no-expression-statement
   })
 
-  tour.start()  
+  tour.start()
 
   return tour
 }

--- a/src/components/issue-page/tour.tsx
+++ b/src/components/issue-page/tour.tsx
@@ -1,0 +1,82 @@
+// tslint:disable:no-expression-statement no-this no-invalid-this
+import delay from '../../utils/delay'
+
+declare var Shepherd: any
+
+const steps = Object.freeze([
+  {
+    text: ['The issue is now posted to the more human internet platform where the site’s maintainer can see and address it.'],
+    attachTo: {
+      element: '.issue-timeline',
+      on: 'top',
+    },
+  },
+  {
+    beforeShowPromise(): Promise<any> {
+      return delay(4000) // issue page waits 6 seconds before acknowledging; 4 seems enough here...
+    },
+    text: ['Looks like Devdiva22 was online and quickly addressed the issue in near real-time.'],
+    attachTo: {
+      element: '#diva-acknowledged',
+      on: 'top',
+    },
+    buttons: [
+      {
+        classes: 'human-pink-bg',
+        text: 'Exit',
+        action(): void {
+          this.cancel()
+        },
+      },
+      {
+        classes: 'human-blue-bg',
+        text: 'Next',
+        action(): void {
+          this.next()
+        },
+        disabled: true
+      },
+    ],
+  },
+])
+
+export function startTour(): any {
+  if (typeof Shepherd === 'undefined') {
+    const script = document.querySelector('script[src="https://shepherdjs.dev/dist/js/shepherd.min.js"]') as HTMLScriptElement
+    script.addEventListener('load', () => startTour())
+    return
+  }
+  const tour = new Shepherd.Tour({
+    defaultStepOptions: {
+      cancelIcon: { enabled: true },
+      buttons: [
+        {
+          classes: 'human-pink-bg',
+          text: 'Exit',
+          action(): void {
+            this.cancel()
+          },
+        },
+        {
+          classes: 'human-blue-bg',
+          text: 'Next',
+          action(): void {
+            this.next()
+          },
+        },
+      ],
+    },
+    useModalOverlay: true,
+  })
+
+  steps.forEach(step => tour.addStep(step))
+
+  tour.once('complete', () => {
+    const postButton = document.querySelector('button.post') as HTMLButtonElement
+    postButton.click() // tslint:disable-line:no-expression-statement
+  })
+
+  tour.start()  
+
+  return tour
+}

--- a/src/pages/issue.tsx
+++ b/src/pages/issue.tsx
@@ -56,8 +56,18 @@ export default function IssuePage(props: { location: Location }): JSX.Element {
     <LayoutWithSidebar mainClassName="issue" currentUser={currentUser} location={props.location}>
       <SEO
         pageTitle="Issue"
-        links={defaultLinks.concat([{ rel: 'stylesheet', type: 'text/css', href: '/trix.css' }])}
-        scripts={[{ type: 'text/javascript', src: '/trix.js' }]}
+        links={[
+          { rel: 'stylesheet', type: 'text/css', href: '/trix.css' },
+          {
+            rel: 'stylesheet',
+            type: 'text/css',
+            href: 'https://shepherdjs.dev/dist/css/shepherd.css',
+          },
+        ]}
+        scripts={[
+          { type: 'text/javascript', src: '/trix.js' },
+          { type: 'text/javascript', src: 'https://shepherdjs.dev/dist/js/shepherd.min.js' },
+        ]}
       />
       <IssueContent issueParams={issueParams} currentUser={currentUser} />
     </LayoutWithSidebar>


### PR DESCRIPTION
Added shepherd tour for issues page.

A little bit still in progress. Biggest open question is how best to coordinate the demo issue page timer for showing acknowledgement with the tour steps. Right now, just using a hardcoded delay in the tour to make sure the issue page timer has completed.