### PR TITLE
no explicit height on iphone

### DIFF
--- a/src/components/new-landing-page/index.tsx
+++ b/src/components/new-landing-page/index.tsx
@@ -14,8 +14,6 @@ const NewLandingPage = ({ location }: PageProps): JSX.Element => {
   const navigator = typeof window === 'undefined' ? undefined : window.navigator
   const { header, internalSectionRefs, dotsRef } = useHeader(location, navigator)
 
-  useExplicitHeightOnIPhone(internalSectionRefs['hero'], internalSectionRefs['Causes']) // tslint:disable-line:no-expression-statement
-
   return (
     <Layout
       additionalClassNames="new-landing-page"


### PR DESCRIPTION
- new hero images for lhkh & roar
- improve images and hoverable learn more links to causes
- improve images and hoverable learn more links to causes
- dont set an explicit height on iphone for the new landing page
